### PR TITLE
Exclude "test" directory from codecov coverage stats

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -8,3 +8,5 @@ coverage:
       default:
         target: 75%    # the required coverage value
         threshold: 1%  # the leniency in hitting the target
+ignore:
+  - "test"


### PR DESCRIPTION
Improve coverage accuracy by excluding "test" folder from Codecov stats.