### PR TITLE
Retrieve custom structs from db

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -15,7 +15,7 @@ class Recipe(ConanFile):
     def requirements(self):
         self.requires("sol2/3.3.0")
         self.requires("sqlitecpp/3.1.1")
-        self.requires("boost/1.79.0")
+        self.requires("boost/1.82.0")
         self.requires("ms-gsl/4.0.0")
         self.requires("luajit/2.1.0-beta3")
         self.requires("sfml/2.5.1")

--- a/src/db/SqliteCppDb.h
+++ b/src/db/SqliteCppDb.h
@@ -96,7 +96,7 @@ class SqliteCppDb
         if (!statement.executeStep()) {
             return {};
         }
-        return { statement.getColumn(0) };
+        return { getElem<Ret>(statement, 0) };
     }
 
     template<typename Ret>
@@ -107,7 +107,7 @@ class SqliteCppDb
         std::vector<Ret> result;
 
         while (statement.executeStep()) {
-            result.emplace_back(statement.getColumn(0));
+            result.emplace_back(getElem<Ret>(statement, 0));
         }
 
         return result;

--- a/src/db/SqliteCppDb.h
+++ b/src/db/SqliteCppDb.h
@@ -48,7 +48,8 @@ class SqliteCppDb
      * @return An optional holding the result of the query. It will be empty if
      * the query didn't return anything. If the query returns fewer columns than
      * specified in template parameters, they will be default initialized.
-     * @tparam Ret Types of the columns. Must be default constructible.
+     * @tparam Ret The type that the result will be stored in can be a tuple
+     * or an aggregate. Must be default constructible.
      */
     template<std::default_initializable Ret>
     [[nodiscard]] auto executeAndGet(const std::string& query) const
@@ -70,7 +71,8 @@ class SqliteCppDb
      * @return A vector holding the result of the query. It will be empty if
      * the query didn't return anything. If the query returns fewer columns than
      * specified in the template parameters, this method will throw.
-     * @tparam Ret Types of the columns. Must be default constructible.
+     * @tparam Ret The type that the result will be stored in can be a tuple
+     * or an aggregate. Must be default constructible.
      */
     template<std::default_initializable Ret>
     [[nodiscard]] auto executeAndGetAll(const std::string& query) const
@@ -88,6 +90,13 @@ class SqliteCppDb
         return result;
     }
 
+    /**
+     * @brief Executes a query that returns a single value in a single column.
+     * @tparam Ret Type of the value to return.
+     * @param query Query to execute.
+     * @return An optional holding the result of the query. It will be empty if
+     * the query didn't return anything.
+     */
     template<typename Ret>
     auto executeAndGet(const std::string& query) const -> std::optional<Ret>
         requires std::convertible_to<SQLite::Column, Ret>
@@ -99,6 +108,14 @@ class SqliteCppDb
         return { getElem<Ret>(statement, 0) };
     }
 
+    /**
+     * @brief Executes a query that returns any number of values in a single
+     * column.
+     * @tparam Ret Type of the values to return.
+     * @param query Query to execute.
+     * @return A vector holding the result of the query. It will be empty if
+     * the query didn't return anything.
+     */
     template<typename Ret>
     auto executeAndGetAll(const std::string& query) const -> std::vector<Ret>
         requires std::convertible_to<SQLite::Column, Ret>

--- a/src/db/SqliteCppDb.h
+++ b/src/db/SqliteCppDb.h
@@ -50,16 +50,15 @@ class SqliteCppDb
      * specified in template parameters, they will be default initialized.
      * @tparam Ret Types of the columns. Must be default constructible.
      */
-    template<typename Ret>
+    template<std::default_initializable Ret>
     [[nodiscard]] auto executeAndGet(const std::string& query) const
       -> std::optional<Ret>
-        requires std::is_default_constructible_v<Ret>
     {
         SQLite::Statement statement(connections[connKey], query);
         if (!statement.executeStep()) {
             return {};
         }
-        Ret result;
+        Ret result{};
         constexpr size_t tupleSize = support::tupleSizeV<Ret>;
         constexpr auto indices =
           std::make_integer_sequence<int, static_cast<int>(tupleSize)>();
@@ -89,10 +88,9 @@ class SqliteCppDb
      * specified in the template parameters, this method will throw.
      * @tparam Ret Types of the columns. Must be default constructible.
      */
-    template<typename Ret>
+    template<std::default_initializable Ret>
     [[nodiscard]] auto executeAndGetAll(const std::string& query) const
       -> std::vector<Ret>
-        requires std::is_default_constructible_v<Ret>
     {
         SQLite::Statement statement(connections[connKey], query);
         std::vector<Ret> result;

--- a/src/db/SqliteCppDb.h
+++ b/src/db/SqliteCppDb.h
@@ -24,6 +24,7 @@ class SqliteCppDb
 {
     thread_local static DatabaseAccessPoint connections;
     std::string connKey;
+
   public:
     /**
      * @brief Constructs a database wrapper.
@@ -52,7 +53,7 @@ class SqliteCppDb
     template<std::default_initializable Ret>
     [[nodiscard]] auto executeAndGet(const std::string& query) const
       -> std::optional<Ret>
-        requires (!std::convertible_to<SQLite::Column, Ret>)
+        requires(!std::convertible_to<SQLite::Column, Ret>)
     {
         SQLite::Statement statement(connections[connKey], query);
         if (!statement.executeStep()) {
@@ -61,7 +62,7 @@ class SqliteCppDb
         Ret result{};
         writeRow(statement, result);
 
-        return {std::move(result)};
+        return { std::move(result) };
     }
     /**
      * @brief Executes a query that returns any number of rows.
@@ -74,7 +75,7 @@ class SqliteCppDb
     template<std::default_initializable Ret>
     [[nodiscard]] auto executeAndGetAll(const std::string& query) const
       -> std::vector<Ret>
-        requires (!std::convertible_to<SQLite::Column, Ret>)
+        requires(!std::convertible_to<SQLite::Column, Ret>)
     {
         SQLite::Statement statement(connections[connKey], query);
         std::vector<Ret> result;
@@ -89,18 +90,18 @@ class SqliteCppDb
 
     template<typename Ret>
     auto executeAndGet(const std::string& query) const -> std::optional<Ret>
-    requires std::convertible_to<SQLite::Column, Ret>
+        requires std::convertible_to<SQLite::Column, Ret>
     {
         SQLite::Statement statement(connections[connKey], query);
         if (!statement.executeStep()) {
             return {};
         }
-        return {statement.getColumn(0)};
+        return { statement.getColumn(0) };
     }
 
     template<typename Ret>
     auto executeAndGetAll(const std::string& query) const -> std::vector<Ret>
-    requires std::convertible_to<SQLite::Column, Ret>
+        requires std::convertible_to<SQLite::Column, Ret>
     {
         SQLite::Statement statement(connections[connKey], query);
         std::vector<Ret> result;
@@ -111,6 +112,7 @@ class SqliteCppDb
 
         return result;
     }
+
   private:
     template<typename ElemType>
     static auto getElem(SQLite::Statement& statement, int index) -> ElemType

--- a/src/support/TupleSize.cpp
+++ b/src/support/TupleSize.cpp
@@ -1,0 +1,5 @@
+//
+// Created by bobini on 14.06.23.
+//
+
+#include "TupleSize.h"

--- a/src/support/TupleSize.h
+++ b/src/support/TupleSize.h
@@ -1,0 +1,41 @@
+//
+// Created by bobini on 14.06.23.
+//
+
+#ifndef RHYTHMGAME_TUPLESIZE_H
+#define RHYTHMGAME_TUPLESIZE_H
+
+#include <boost/pfr/tuple_size.hpp>
+namespace support {
+
+template<typename T>
+    requires requires {
+        {
+            std::tuple_size<T>::value
+        };
+    } || std::is_aggregate_v<T>
+class TupleSize
+{
+  static constexpr auto tupleSizeImpl() -> std::size_t
+    {
+        if constexpr (requires {
+                          {
+                              std::tuple_size<T>::value
+                          };
+                      }) {
+            return std::tuple_size<T>::value;
+        } else {
+            return boost::pfr::tuple_size<T>::value;
+        }
+    }
+public:
+    static constexpr auto
+    value = tupleSizeImpl();
+};
+
+template<typename T>
+constexpr auto tupleSizeV = TupleSize<T>::value;
+
+} // namespace support
+
+#endif // RHYTHMGAME_TUPLESIZE_H

--- a/src/support/TupleSize.h
+++ b/src/support/TupleSize.h
@@ -8,6 +8,10 @@
 #include <boost/pfr/tuple_size.hpp>
 namespace support {
 
+/**
+ * @brief Used to get the size of a tuple or an aggregate.
+ * @tparam T Type of the tuple or aggregate to check.
+ */
 template<typename T>
     requires requires {
         {

--- a/src/support/get.cpp
+++ b/src/support/get.cpp
@@ -1,0 +1,5 @@
+//
+// Created by bobini on 14.06.23.
+//
+
+#include "get.h"

--- a/src/support/get.h
+++ b/src/support/get.h
@@ -1,0 +1,34 @@
+//
+// Created by bobini on 14.06.23.
+//
+
+#ifndef RHYTHMGAME_GET_H
+#define RHYTHMGAME_GET_H
+
+#include <boost/pfr/tuple_size.hpp>
+#include <boost/pfr/core.hpp>
+namespace support {
+
+template<std::size_t N, typename T>
+constexpr auto
+get(T&& t) -> auto& requires ([]{
+            using std::get;
+            return requires {
+                get<N>(t);
+            };
+        }())
+{
+    using std::get;
+    return get<N>(t);
+}
+
+template<std::size_t N, typename T>
+constexpr auto
+get(T&& aggregate) -> auto& requires std::is_aggregate_v<std::remove_cvref_t<T>>
+{
+    return boost::pfr::get<N>(aggregate);
+}
+
+} // namespace support
+
+#endif // RHYTHMGAME_GET_H

--- a/src/support/get.h
+++ b/src/support/get.h
@@ -9,6 +9,13 @@
 #include <boost/pfr/core.hpp>
 
 namespace support {
+/**
+ * @brief Returns the nth element of a type that supports std::get.
+ * @tparam N Index of the element to get.
+ * @tparam T Type of the object to get the element from.
+ * @param t Object to get the element from.
+ * @return A reference to nth element of the object.
+ */
 template<std::size_t N, typename T>
 constexpr auto
 get(T&& t) -> auto&
@@ -17,6 +24,13 @@ get(T&& t) -> auto&
     return std::get<N>(t);
 }
 
+/**
+ * @brief Returns the nth member of an aggregate.
+ * @tparam N Index of the element to get.
+ * @tparam T Type of the aggregate.
+ * @param aggregate Aggregate to get the element from.
+ * @return A reference to nth member of the aggregate.
+ */
 template<std::size_t N, typename T>
 constexpr auto
 get(T&& aggregate) -> auto&

--- a/src/support/get.h
+++ b/src/support/get.h
@@ -8,15 +8,18 @@
 #include <boost/pfr/tuple_size.hpp>
 #include <boost/pfr/core.hpp>
 namespace support {
+template<std::size_t N, typename T>
+constexpr auto stdGettable() -> bool
+{
+    using std::get;
+    return requires {
+        get<N>(std::declval<T>());
+    };
+}
 
 template<std::size_t N, typename T>
 constexpr auto
-get(T&& t) -> auto& requires ([]{
-            using std::get;
-            return requires {
-                get<N>(t);
-            };
-        }())
+get(T&& t) -> auto& requires (stdGettable<N, T>())
 {
     using std::get;
     return get<N>(t);

--- a/src/support/get.h
+++ b/src/support/get.h
@@ -7,27 +7,20 @@
 
 #include <boost/pfr/tuple_size.hpp>
 #include <boost/pfr/core.hpp>
+
 namespace support {
 template<std::size_t N, typename T>
-constexpr auto stdGettable() -> bool
+constexpr auto
+get(T&& t) -> auto&
+    requires requires { std::get<N>(std::declval<T>()); }
 {
-    using std::get;
-    return requires {
-        get<N>(std::declval<T>());
-    };
+    return std::get<N>(t);
 }
 
 template<std::size_t N, typename T>
 constexpr auto
-get(T&& t) -> auto& requires (stdGettable<N, T>())
-{
-    using std::get;
-    return get<N>(t);
-}
-
-template<std::size_t N, typename T>
-constexpr auto
-get(T&& aggregate) -> auto& requires std::is_aggregate_v<std::remove_cvref_t<T>>
+get(T&& aggregate) -> auto&
+    requires std::is_aggregate_v<std::remove_cvref_t<T>>
 {
     return boost::pfr::get<N>(aggregate);
 }

--- a/test/db/SqliteCppDb.test.cpp
+++ b/test/db/SqliteCppDb.test.cpp
@@ -102,3 +102,21 @@ TEST_CASE("Values can be inserted into custom aggregate structs",
     REQUIRE(x == 1);
     REQUIRE(y == "TestName"s);
 }
+
+TEST_CASE("Simple scalar types don't need to be wrapped in structs or tuples", "[SqliteCppDb]")
+{
+    using namespace std::string_literals;
+    auto db = getDb("test5.db"s);
+    REQUIRE_FALSE(db.hasTable("Test"));
+    db.execute("CREATE TABLE Test(ID int, Name VARCHAR(255))"s);
+    db.execute("INSERT INTO Test VALUES (1, 'TestName')"s);
+    auto row = db.executeAndGet<int>("SELECT ID FROM Test WHERE ID = 1"s);
+    REQUIRE(row);
+    auto& x = row.value();
+    REQUIRE(x == 1);
+
+    auto rows = db.executeAndGetAll<int>("SELECT ID FROM Test"s);
+    REQUIRE(rows.size() == 1);
+    row = rows[0];
+    REQUIRE(x == 1);
+}

--- a/test/db/SqliteCppDb.test.cpp
+++ b/test/db/SqliteCppDb.test.cpp
@@ -23,14 +23,15 @@ TEST_CASE("Values can be inserted and retrieved from tables", "[SqliteCppDb]")
     db.execute("CREATE TABLE Test(ID int, Name VARCHAR(255))"s);
     REQUIRE(db.hasTable("Test"));
     db.execute("INSERT INTO Test VALUES (1, 'TestName')"s);
-    auto row =
-      db.executeAndGet<std::tuple<int, std::string>>("SELECT * FROM Test WHERE ID = 1"s);
+    auto row = db.executeAndGet<std::tuple<int, std::string>>(
+      "SELECT * FROM Test WHERE ID = 1"s);
     auto& [x, y] = row.value();
     REQUIRE(x == 1);
     REQUIRE(y == "TestName"s);
     db.execute("INSERT INTO Test VALUES (2, 'SecondRowName')"s);
     db.execute("INSERT INTO Test VALUES (69, 'ThirdRowName')"s);
-    auto rows = db.executeAndGetAll<std::tuple<int, std::string>>("SELECT * FROM Test"s);
+    auto rows =
+      db.executeAndGetAll<std::tuple<int, std::string>>("SELECT * FROM Test"s);
     row = rows[1];
     REQUIRE(x == 2);
     REQUIRE(y == "SecondRowName"s);
@@ -45,10 +46,11 @@ TEST_CASE("Failing queries correctly return empty results", "[SqliteCppDb]")
     auto db = getDb("test2.db"s);
     REQUIRE_FALSE(db.hasTable("Test"));
     db.execute("CREATE TABLE Test(ID int, Name VARCHAR(255))"s);
-    auto row =
-      db.executeAndGet<std::tuple<int, std::string>>("SELECT * FROM Test WHERE ID = 1"s);
+    auto row = db.executeAndGet<std::tuple<int, std::string>>(
+      "SELECT * FROM Test WHERE ID = 1"s);
     REQUIRE_FALSE(row);
-    auto rows = db.executeAndGetAll<std::tuple<int, std::string>>("SELECT * FROM Test"s);
+    auto rows =
+      db.executeAndGetAll<std::tuple<int, std::string>>("SELECT * FROM Test"s);
     REQUIRE(rows.empty());
 }
 
@@ -59,8 +61,8 @@ TEST_CASE("Database wrapper can be passed to another thread", "[SqliteCppDb]")
     REQUIRE_FALSE(db.hasTable("Test"));
     db.execute("CREATE TABLE Test(ID int, Name VARCHAR(255))"s);
     db.execute("INSERT INTO Test VALUES (1, 'TestName')"s);
-    auto row =
-      db.executeAndGet<std::tuple<int, std::string>>("SELECT * FROM Test WHERE ID = 1"s);
+    auto row = db.executeAndGet<std::tuple<int, std::string>>(
+      "SELECT * FROM Test WHERE ID = 1"s);
     auto& [x, y] = row.value();
     REQUIRE(x == 1);
     REQUIRE(y == "TestName"s);
@@ -74,7 +76,8 @@ TEST_CASE("Database wrapper can be passed to another thread", "[SqliteCppDb]")
     thread.join();
 }
 
-TEST_CASE("Values can be inserted into custom aggregate structs", "[SqliteCppDb]")
+TEST_CASE("Values can be inserted into custom aggregate structs",
+          "[SqliteCppDb]")
 {
     using namespace std::string_literals;
     struct TestStruct

--- a/test/db/SqliteCppDb.test.cpp
+++ b/test/db/SqliteCppDb.test.cpp
@@ -103,7 +103,8 @@ TEST_CASE("Values can be inserted into custom aggregate structs",
     REQUIRE(y == "TestName"s);
 }
 
-TEST_CASE("Simple scalar types don't need to be wrapped in structs or tuples", "[SqliteCppDb]")
+TEST_CASE("Simple scalar types don't need to be wrapped in structs or tuples",
+          "[SqliteCppDb]")
 {
     using namespace std::string_literals;
     auto db = getDb("test5.db"s);

--- a/test/db/SqliteCppDb.test.cpp
+++ b/test/db/SqliteCppDb.test.cpp
@@ -24,13 +24,13 @@ TEST_CASE("Values can be inserted and retrieved from tables", "[SqliteCppDb]")
     REQUIRE(db.hasTable("Test"));
     db.execute("INSERT INTO Test VALUES (1, 'TestName')"s);
     auto row =
-      db.executeAndGet<int, std::string>("SELECT * FROM Test WHERE ID = 1"s);
+      db.executeAndGet<std::tuple<int, std::string>>("SELECT * FROM Test WHERE ID = 1"s);
     auto& [x, y] = row.value();
     REQUIRE(x == 1);
     REQUIRE(y == "TestName"s);
     db.execute("INSERT INTO Test VALUES (2, 'SecondRowName')"s);
     db.execute("INSERT INTO Test VALUES (69, 'ThirdRowName')"s);
-    auto rows = db.executeAndGetAll<int, std::string>("SELECT * FROM Test"s);
+    auto rows = db.executeAndGetAll<std::tuple<int, std::string>>("SELECT * FROM Test"s);
     row = rows[1];
     REQUIRE(x == 2);
     REQUIRE(y == "SecondRowName"s);
@@ -46,9 +46,9 @@ TEST_CASE("Failing queries correctly return empty results", "[SqliteCppDb]")
     REQUIRE_FALSE(db.hasTable("Test"));
     db.execute("CREATE TABLE Test(ID int, Name VARCHAR(255))"s);
     auto row =
-      db.executeAndGet<int, std::string>("SELECT * FROM Test WHERE ID = 1"s);
+      db.executeAndGet<std::tuple<int, std::string>>("SELECT * FROM Test WHERE ID = 1"s);
     REQUIRE_FALSE(row);
-    auto rows = db.executeAndGetAll<int, std::string>("SELECT * FROM Test"s);
+    auto rows = db.executeAndGetAll<std::tuple<int, std::string>>("SELECT * FROM Test"s);
     REQUIRE(rows.empty());
 }
 
@@ -60,16 +60,42 @@ TEST_CASE("Database wrapper can be passed to another thread", "[SqliteCppDb]")
     db.execute("CREATE TABLE Test(ID int, Name VARCHAR(255))"s);
     db.execute("INSERT INTO Test VALUES (1, 'TestName')"s);
     auto row =
-      db.executeAndGet<int, std::string>("SELECT * FROM Test WHERE ID = 1"s);
+      db.executeAndGet<std::tuple<int, std::string>>("SELECT * FROM Test WHERE ID = 1"s);
     auto& [x, y] = row.value();
     REQUIRE(x == 1);
     REQUIRE(y == "TestName"s);
     auto thread = std::thread{ [&db]() {
-        auto row = db.executeAndGet<int, std::string>(
+        auto row = db.executeAndGet<std::tuple<int, std::string>>(
           "SELECT * FROM Test WHERE ID = 1"s);
         auto& [z, w] = row.value();
         REQUIRE(z == 1);
         REQUIRE(w == "TestName"s);
     } };
     thread.join();
+}
+
+TEST_CASE("Values can be inserted into custom aggregate structs", "[SqliteCppDb]")
+{
+    using namespace std::string_literals;
+    struct TestStruct
+    {
+        int x;
+        std::string y;
+    };
+    static_assert(std::is_aggregate_v<TestStruct>);
+    auto db = getDb("test4.db"s);
+    REQUIRE_FALSE(db.hasTable("Test"));
+    db.execute("CREATE TABLE Test(ID int, Name VARCHAR(255))"s);
+    db.execute("INSERT INTO Test VALUES (1, 'TestName')"s);
+    auto row = db.executeAndGet<TestStruct>("SELECT * FROM Test WHERE ID = 1"s);
+    REQUIRE(row);
+    auto& [x, y] = row.value();
+    REQUIRE(x == 1);
+    REQUIRE(y == "TestName"s);
+
+    auto rows = db.executeAndGetAll<TestStruct>("SELECT * FROM Test"s);
+    REQUIRE(rows.size() == 1);
+    row = rows[0];
+    REQUIRE(x == 1);
+    REQUIRE(y == "TestName"s);
 }


### PR DESCRIPTION
This PR modifies two functions of the SQliteCppDb class, `executeAndGet` and `executeAndGetAll` to allow for retrieving custom structs instead of forcing tuples. This was done with the help of Boost PFR.
Thanks for the idea, DD.