### PR TITLE
Scancode-based input

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,6 +261,12 @@ else ()
     target_link_libraries(RhythmGame_lib PUBLIC llfio::sl)
 endif ()
 
+if (LINUX)
+    find_package(PkgConfig REQUIRED)
+    pkg_check_modules(xkbcommon REQUIRED IMPORTED_TARGET xkbcommon)
+    target_link_libraries(RhythmGame_lib PUBLIC PkgConfig::xkbcommon)
+endif ()
+
 # We all love MSVC.
 target_compile_definitions(RhythmGame_lib PUBLIC NOMINMAX)
 
@@ -281,7 +287,7 @@ qt_import_qml_plugins(RhythmGame_qmlplugin)
 if (WIN32)
     enable_language("RC")
     qt_add_executable(RhythmGame_exe
-            src/main.cpp  ${CMAKE_CURRENT_SOURCE_DIR}/staticAssets/RhythmGame.rc
+            src/main.cpp ${CMAKE_CURRENT_SOURCE_DIR}/staticAssets/RhythmGame.rc
     )
     set_target_properties(RhythmGame_exe PROPERTIES
             WIN32_EXECUTABLE $<IF:$<CONFIG:Debug,RelWithDebInfo>,FALSE,TRUE>

--- a/src/input/CustomNotifyApp.cpp
+++ b/src/input/CustomNotifyApp.cpp
@@ -19,4 +19,4 @@ CustomNotifyApp::notify(QObject* receiver, QEvent* event)
     }
     return notifyResult;
 }
-} // input
+} // namespace input

--- a/src/input/InputTranslator.cpp
+++ b/src/input/InputTranslator.cpp
@@ -12,6 +12,8 @@
 #include <QVariant>
 #ifdef _WIN32
 #include <windows.h>
+#elifdef __linux__
+#include <xkbcommon/xkbcommon.h>
 #endif
 
 namespace input {
@@ -1180,6 +1182,18 @@ InputTranslator::scancodeToString(const int scanCode)
 
     if (result > 0) {
         return QString::fromWCharArray(keyName);
+    }
+#elifdef __linux__
+    static xkb_context *ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
+    static xkb_keymap *keymap = xkb_keymap_new_from_names(ctx, nullptr, XKB_KEYMAP_COMPILE_NO_FLAGS);
+    static xkb_state *state = xkb_state_new(keymap);
+
+    xkb_keysym_t sym = xkb_state_key_get_one_sym(state, scanCode);
+
+    char buf[64];
+    xkb_keysym_get_name(sym, buf, sizeof(buf));
+    if (buf[0] != '\0') {
+        return QString::fromUtf8(buf);
     }
 #endif
     return QString("Scancode %1").arg(scanCode);

--- a/src/input/InputTranslator.h
+++ b/src/input/InputTranslator.h
@@ -27,7 +27,7 @@ class Key
      */
     Q_PROPERTY(QVariant gamepad MEMBER gamepad)
     Q_PROPERTY(Device device MEMBER device)
-    Q_PROPERTY(int code MEMBER code)
+    Q_PROPERTY(quint32 code MEMBER code)
     Q_PROPERTY(Direction direction MEMBER direction)
 
   public:
@@ -48,7 +48,7 @@ class Key
 
     QVariant gamepad = QVariant::fromValue(nullptr);
     Device device;
-    int code;
+    quint32 code;
     Direction direction{};
 
     friend auto operator>>(QDataStream& stream, Key& key) -> QDataStream&;
@@ -281,7 +281,7 @@ class InputTranslator final : public QObject
     auto getAnalogAxisConfig1() -> AnalogAxisConfig*;
     auto getAnalogAxisConfig2() -> AnalogAxisConfig*;
     auto eventFilter(QObject* watched, QEvent* event) -> bool override;
-    Q_INVOKABLE static QString scancodeToString(int scancode);
+    Q_INVOKABLE static QString scancodeToString(int virtualKey);
 
   signals:
     void buttonPressed(BmsKey button, int64_t time);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,7 +68,6 @@ qtLogHandler(QtMsgType type,
     }
 }
 
-
 auto
 main(int argc, [[maybe_unused]] char* argv[]) -> int
 {
@@ -143,8 +142,10 @@ main(int argc, [[maybe_unused]] char* argv[]) -> int
                                        dataFolder / "profiles",
                                        avatarPath };
 
-        auto setUseSystemTimestamps = [&profileList, &inputTranslator,
-                                       connection = QMetaObject::Connection{}]() mutable {
+        auto setUseSystemTimestamps = [&profileList,
+                                       &inputTranslator,
+                                       connection =
+                                         QMetaObject::Connection{}]() mutable {
             inputTranslator.setUseSystemTimestamps(
               profileList.getMainProfile()
                 ->getVars()
@@ -181,7 +182,8 @@ main(int argc, [[maybe_unused]] char* argv[]) -> int
                          &input::InputTranslator::handleRelease);
 
         auto audioEngine = sounds::AudioEngine{};
-        auto chartFactory = resource_managers::ChartFactory{ &audioEngine, &inputTranslator };
+        auto chartFactory =
+          resource_managers::ChartFactory{ &audioEngine, &inputTranslator };
         auto chartDataFactory = resource_managers::ChartDataFactory{};
         auto gaugeFactoryGeneral = resource_managers::GaugeFactory{};
         auto gaugeFactory =
@@ -248,7 +250,6 @@ main(int argc, [[maybe_unused]] char* argv[]) -> int
         auto tables = resource_managers::Tables{ &networkManager,
                                                  dataFolder / "tables",
                                                  &db };
-
 
         auto engine = QQmlApplicationEngine{};
         auto languages =
@@ -427,6 +428,12 @@ main(int argc, [[maybe_unused]] char* argv[]) -> int
             throw std::runtime_error{ "Failed to load main qml" };
         }
         app.setInputTranslator(&inputTranslator);
+
+        auto stmt = db.createStatement(
+          "INSERT OR REPLACE INTO properties (key, value) VALUES "
+          "('version', ?);");
+        stmt.bind(1, static_cast<int64_t>(support::currentVersion));
+        stmt.execute();
 
         return app.exec();
     } catch (const std::exception& e) {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -134,6 +134,8 @@ main(int argc, [[maybe_unused]] char* argv[]) -> int
         auto gamepadManager = input::GamepadManager{};
 
         auto themes = qml_components::Themes{ availableThemes };
+
+        auto inputTranslator = input::InputTranslator{ &db };
         auto profileList =
           qml_components::ProfileList{ dataFolder / "song_db.sqlite",
                                        &db,
@@ -141,7 +143,6 @@ main(int argc, [[maybe_unused]] char* argv[]) -> int
                                        dataFolder / "profiles",
                                        avatarPath };
 
-        auto inputTranslator = input::InputTranslator{ &db };
         auto setUseSystemTimestamps = [&profileList, &inputTranslator,
                                        connection = QMetaObject::Connection{}]() mutable {
             inputTranslator.setUseSystemTimestamps(

--- a/src/resource_managers/DefineDb.cpp
+++ b/src/resource_managers/DefineDb.cpp
@@ -101,12 +101,6 @@ defineDb(db::SqliteCppDb& db)
                "value"
                ");");
 
-    auto stmt =
-      db.createStatement("INSERT OR IGNORE INTO properties (key, value) VALUES "
-                         "('version', ?);");
-    stmt.bind(1, static_cast<int64_t>(support::currentVersion));
-    stmt.execute();
-
     db.execute("CREATE TABLE IF NOT EXISTS preview_files ("
                "id INTEGER PRIMARY KEY AUTOINCREMENT,"
                "path TEXT NOT NULL,"

--- a/src/resource_managers/Profile.cpp
+++ b/src/resource_managers/Profile.cpp
@@ -126,6 +126,11 @@ Profile::Profile(
     auto guidResult =
       getGuid.executeAndGet<std::string>().value_or(std::string{});
     guid = QString::fromStdString(guidResult);
+    auto stmt = db.createStatement(
+      "INSERT OR REPLACE INTO properties (key, value) VALUES "
+      "('version', ?);");
+    stmt.bind(1, static_cast<int64_t>(support::currentVersion));
+    stmt.execute();
 }
 auto
 Profile::getPath() const -> std::filesystem::path

--- a/src/sounds/SoundBuffer.h
+++ b/src/sounds/SoundBuffer.h
@@ -5,7 +5,7 @@
 #ifndef RHYTHMGAME_SOUNDBUFFER_H
 #define RHYTHMGAME_SOUNDBUFFER_H
 #include "AudioEngine.h"
-
+#include <vector>
 #include <filesystem>
 
 namespace sounds {


### PR DESCRIPTION
Solves https://github.com/Bobini1/RhythmGame/issues/63.

Instead of using keycodes, we're going to use layout-independent scancodes.

This update also wipes key configs that were previously configured.