### PR TITLE
Fix docs deploy permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -641,6 +641,9 @@ jobs:
   docs:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: write
+
     if: github.ref == 'refs/heads/master'
       && github.event_name == 'push'
       && github.repository_owner == 'Bobini1'


### PR DESCRIPTION
## Summary
- grant the docs job `contents: write` so `peaceiris/actions-gh-pages` can push the generated docs to `gh-pages`

## Verification
- parsed `.github/workflows/ci.yml` with PyYAML
- checked the failed master run logs: docs generation passed and the deploy step failed with `Permission to Bobini1/RhythmGame.git denied to github-actions[bot]` because the job token only had `Contents: read`