### PR TITLE
Pass Codecov upload token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,7 @@ jobs:
       - name: Submit to codecov.io
         uses: codecov/codecov-action@v7
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: build/coverage/coverage.info
 
   sanitize:


### PR DESCRIPTION
## Summary
- pass `secrets.CODECOV_TOKEN` to `codecov/codecov-action@v7` so protected-branch uploads can be processed

## Why
Codecov accepted the upload from `master`, then refused to process it with `Token required because branch is protected`. The workflow was using tokenless upload.

## Verification
- parsed `.github/workflows/ci.yml` with PyYAML
- ran `git diff --check` for the workflow change