### PR TITLE
Make Codecov informational

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,7 @@ jobs:
 
       - name: Submit to codecov.io
         uses: codecov/codecov-action@v7
+        continue-on-error: true
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: build/coverage/coverage.info

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,9 +4,11 @@ coverage:
       default:
         target: 75%    # the required coverage value
         threshold: 1%  # the leniency in hitting the target
+        informational: true
     patch:
       default:
         target: 75%    # the required coverage value
         threshold: 1%  # the leniency in hitting the target
+        informational: true
 ignore:
   - "test"


### PR DESCRIPTION
## Summary
- mark Codecov project and patch coverage statuses as informational
- keep the Codecov upload step non-fatal with `continue-on-error`

## Why
Coverage is useful signal, but the current thresholds are aspirational and should not block CI while the project is below them.

## Verification
- parsed `.github/workflows/ci.yml` and `codecov.yml` with PyYAML
- ran `git diff --check` for both files